### PR TITLE
Fix CS lineLimit + remove --xdebug phpstan option

### DIFF
--- a/make/qualimetry.mk
+++ b/make/qualimetry.mk
@@ -33,7 +33,7 @@ metrics: ## Build static analysis from the php in src. Repports available in ./b
 
 .PHONY: phpstan
 phpstan: ## Launch PHP Static Analysis
-	vendor/bin/phpstan analyse src tests --level=7 --xdebug -c phpstan.neon
+	vendor/bin/phpstan analyse src tests --level=7 -c phpstan.neon
 
 .PHONY: qualimetry qa
 qualimetry: phpstan checkstyle lint-php lint-twig lint-yaml lint-container composer-validate ## Launch all qualimetry rules. Shortcut "make qa"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,6 +10,11 @@
 
     <rule ref="PSR12">
     </rule>
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="150"/>
+        </properties>
+    </rule>
 
     <file>bin/</file>
     <file>config/</file>


### PR DESCRIPTION
## Fixed
- Fix removed lineLimit mentioned on 10a086144e94794515e6bc544ae755b16892e907 due to dynamic property on the PSR12 ruleset. ⇾ The solution was to set it on the Generic.Files.LineLength ruleset

## Removed
- Remove the option --xdebug and warning for phpstan because we now handle that through the XDEBUG_MODE env var on our stack cf. https://github.com/smartbooster/symfony-docker/blob/main/docker-compose.yml#L21