### PR TITLE
`composer.json` : Allow using dama/doctrine-test-bundle version ^6.7 …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 CHANGELOG for 1.x
 ===================
+## v1.0.4 - (2024-01-22)
+
+### Added
+
+- `composer.json` : Allow using dama/doctrine-test-bundle version ^6.7 to reduce the need of updating doctrine/dbal
+
 ## v1.0.3 - (2024-01-22)
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^8.1",
-    "dama/doctrine-test-bundle": "^7.1",
+    "dama/doctrine-test-bundle": "^6.7|^7.1",
     "doctrine/orm": "^2.13",
     "liip/test-fixtures-bundle": "^2.4",
     "phpmetrics/phpmetrics": "^2.8",


### PR DESCRIPTION
…to reduce the need of updating doctrine/dbal