### PR TITLE
Adjust dependencies to allow `doctrine/orm` ^v3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 CHANGELOG for 1.x
 ===================
+## v1.4.1 - (2025-04-15)
+### Added
+- Allow `doctrine/orm` ^v3.0
+
+### Changed
+- Moved `phpmetrics/phpmetrics` as suggested vendor package becasue it's not on the qualimetry calls command and also because it requires use to do a
+  downgrade of `nikic/php-parser` from 5.0 to 4.18 on default symfony-docker install which is needed by the `symfony/maker-bundle`
+
 ## v1.4.0 - (2026-02-25)
 ### Added
 - Allow Symfony 7.4

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,10 @@
     "php": "^8.1",
     "dama/doctrine-test-bundle": "^6.7|^7.1|^8.0",
     "dealerdirect/phpcodesniffer-composer-installer": "^1.2",
-    "doctrine/orm": "^2.13",
+    "doctrine/orm": "^2.13|^3.0",
     "friendsofphp/php-cs-fixer": "^3.86",
     "liip/test-fixtures-bundle": "^2.4|^3.0",
     "pheromone/phpcs-security-audit": "^2.0",
-    "phpmetrics/phpmetrics": "^2.8",
     "phpstan/phpstan-doctrine": "^1.3|^2.0",
     "phpstan/phpstan-symfony": "^1.2|^2.0",
     "spaze/phpstan-disallowed-calls": "^4.7",
@@ -27,6 +26,9 @@
     "symfony/framework-bundle": "^5.4|^6.2|^7.4",
     "symfony/validator": "^5.4|^6.2|^7.4",
     "yamadashy/phpstan-friendly-formatter": "^1.3"
+  },
+  "suggest": {
+    "phpmetrics/phpmetrics": "Build static analysis from the php in src with make metrics command. Require to have nikic/php-parser ^4.18 to run."
   },
   "autoload": {
     "psr-4": {

--- a/smartbooster.standard-bundle.1.4.1.json
+++ b/smartbooster.standard-bundle.1.4.1.json
@@ -1,0 +1,29 @@
+{
+  "manifests": {
+    "smartbooster/standard-bundle": {
+      "manifest": {
+        "bundles": {
+          "DAMA\\DoctrineTestBundle\\DAMADoctrineTestBundle": ["test"],
+          "Liip\\TestFixturesBundle\\LiipTestFixturesBundle": ["test"],
+          "Smart\\StandardBundle\\SmartStandardBundle": ["dev", "test"]
+        },
+        "copy-from-package": {
+          "config/packages/dama_doctrine_test_bundle.yaml": "%CONFIG_DIR%/packages/test/dama_doctrine_test_bundle.yaml",
+          "config/packages/liip_test_fixtures.yaml": "%CONFIG_DIR%/packages/test/liip_test_fixtures.yaml",
+          "make/dev.mk": "make/dev.mk",
+          "make/qualimetry.mk": "make/qualimetry.mk",
+          "make/test.mk": "make/test.mk",
+          "tests/bootstrap.php": "tests/bootstrap.php",
+          "phpcs.xml": "phpcs.xml",
+          "phpstan.neon": "phpstan.neon",
+          "phpunit.xml.dist": "phpunit.xml.dist",
+          ".php-cs-fixer.dist.php": ".php-cs-fixer.dist.php"
+        },
+        "gitignore": [
+          "/.phpcs-cache"
+        ]
+      },
+      "ref": "87a9aec1dcacd54d949b354adadf4c45e9ebf92f"
+    }
+  }
+}


### PR DESCRIPTION
Waiting https://github.com/getsentry/sentry-symfony/issues/806 to being fixed before allowing `doctrine/orm` ^v3.0.

It is related to a fatal error trigger by TracingStatementForV3 which doesn't work properly with `doctrine/dbal` v4 (which is require by `doctrine/orm` ^v3.0)
